### PR TITLE
use argon2id13 strictly

### DIFF
--- a/Sodium/SFSodium.swift
+++ b/Sodium/SFSodium.swift
@@ -78,7 +78,8 @@ public class SFSodium : NSObject {
                                       passwd: passwordBytes,
                                       salt: saltBytes,
                                       opsLimit: sodium.pwHash.OpsLimitInteractive,
-                                      memLimit: sodium.pwHash.MemLimitInteractive)
+                                      memLimit: sodium.pwHash.MemLimitInteractive,
+                                      alg: PWHash.Alg.Argon2ID13)
         
         return hash
     }


### PR DESCRIPTION
Stick to exact (currently best from security perspective) version of hashing algo, and prevents it automatic changing. 

[from docs](https://download.libsodium.org/doc/password_hashing/the_argon2i_function#key-derivation):

```
alg is an identifier for the algorithm to use, and should be set to one of the following values:
* crypto_pwhash_ALG_DEFAULT: the currently recommended algorithm, which can
change from one version of libsodium to another.
* crypto_pwhash_ALG_ARGON2I13: version 1.3 of the Argon2i algorithm.
* crypto_pwhash_ALG_ARGON2ID13: version 1.3 of the Argon2id algorithm,
available since libsodium 1.0.13.
```


If some app that uses this fork will need to change hashing algo version, it can do it explicitly (with updating `encryption_version` to preserve backwards compatibility).